### PR TITLE
WIP: config: use cfg file instead of env in docker-services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 # See https://github.com/travis-ci/travis-ci/issues/8836
 sudo: required
 
-dist: trusty # Chrome driver fails if not trusty dist
+dist: bionic
 
 notifications:
   email: false

--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+check-manifest = ">=0.25"
 
 [packages]
 invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = ">=1.0.0a3"}

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -50,7 +50,7 @@ services:
       service: frontend
     volumes:
       - static_data:/opt/invenio/var/instance/static
-    links:
+    depends_on:
       - web-ui
       - web-api
     ports:
@@ -69,11 +69,16 @@ services:
       - static_data:/opt/invenio/var/instance/static
       - uploaded_data:/opt/invenio/var/instance/data
       - archived_data:/opt/invenio/var/instance/archive
-    links:
-      - cache
-      - es
-      - mq
-      - db
+    depends_on:
+      es:
+        condition: service_healthy
+      cache:
+        condition: service_started
+      db:
+        condition: service_started
+      mq:
+        condition: service_started
+
   # API Rest Application
   web-api:
     extends:
@@ -86,11 +91,15 @@ services:
     volumes:
       - uploaded_data:/opt/invenio/var/instance/data
       - archived_data:/opt/invenio/var/instance/archive
-    links:
-      - cache
-      - es
-      - mq
-      - db
+    depends_on:
+      es:
+        condition: service_healthy
+      cache:
+        condition: service_started
+      db:
+        condition: service_started
+      mq:
+        condition: service_started
   # Worker
   worker:
     extends:
@@ -99,11 +108,15 @@ services:
     restart: "always"
     command: ["celery worker -A invenio_app.celery --loglevel=INFO"]
     image: {{cookiecutter.project_shortname}}
-    links:
-      - cache
-      - es
-      - mq
-      - db
+    depends_on:
+      es:
+        condition: service_healthy
+      cache:
+        condition: service_started
+      db:
+        condition: service_started
+      mq:
+        condition: service_started
 volumes:
   static_data:
   uploaded_data:

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -92,6 +92,11 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.type=single-node
+    healthcheck:
+      test: ["CMD", "curl", "-f", "localhost:9200/_cluster/health?wait_for_status=green"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
     ulimits:
       memlock:
         soft: -1

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -1,0 +1,15 @@
+ACCOUNTS_SESSION_REDIS_URL="redis://localhost:6379/1"
+BROKER_URL="amqp://guest:guest@localhost:5672/"
+CACHE_REDIS_URL="redis://localhost:6379/0"
+CACHE_TYPE="redis"
+CELERY_BROKER_URL="amqp://guest:guest@localhost:5672/"
+CELERY_RESULT_BACKEND="redis://localhost:6379/2"
+SEARCH_ELASTIC_HOSTS=[{"host": "localhost", "port": 9200}]
+SECRET_KEY="CHANGE_ME"
+{%- if cookiecutter.database == 'postgresql'%}
+SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@localhost/{{cookiecutter.project_shortname}}"
+{%- elif cookiecutter.database == 'mysql'%}
+SQLALCHEMY_DATABASE_URI="mysql+pymysql://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@localhost/{{cookiecutter.project_shortname}}"
+{%- endif %}
+WSGI_PROXIES=2
+RATELIMIT_STORAGE_URL="redis://localhost:6379/3"

--- a/{{cookiecutter.project_shortname}}/scripts/bootstrap
+++ b/{{cookiecutter.project_shortname}}/scripts/bootstrap
@@ -27,4 +27,4 @@ pipenv run invenio collect -v
 pipenv run invenio webpack buildall
 
 cp -f $script_path/../static/images/logo.svg $(pipenv run invenio shell --no-term-title -c "print(app.instance_path)")/static/images/logo.svg
-ln -s $(realpath $script_path/../invenio.cfg) $(pipenv run invenio shell --no-term-title -c "print(app.instance_path)")/invenio.cfg
+ln --symbolic --force $(realpath $script_path/../invenio.cfg) $(pipenv run invenio shell --no-term-title -c "print(app.instance_path)")/invenio.cfg

--- a/{{cookiecutter.project_shortname}}/scripts/bootstrap
+++ b/{{cookiecutter.project_shortname}}/scripts/bootstrap
@@ -27,3 +27,4 @@ pipenv run invenio collect -v
 pipenv run invenio webpack buildall
 
 cp -f $script_path/../static/images/logo.svg $(pipenv run invenio shell --no-term-title -c "print(app.instance_path)")/static/images/logo.svg
+ln -s $(realpath $script_path/../invenio.cfg) $(pipenv run invenio shell --no-term-title -c "print(app.instance_path)")/invenio.cfg


### PR DESCRIPTION
Partially addresses https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/11 since it uses the invenio.cfg file only for the `dev` environment. Mainly due to the lack of distinction between `localhots` or named hosts in the docker network such as `mq`, `es`, etc.

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/23