### PR TITLE
customization: remove logo name and format dependency

### DIFF
--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -30,7 +30,4 @@ RUN invenio collect -v  && \
     invenio webpack install --unsafe && \
     invenio webpack build
 
-ENV INVENIO_THEME_LOGO="images/logo.svg"
-ADD ./static/images/logo.svg ${INVENIO_INSTANCE_PATH}/static/images/logo.svg
-
 ENTRYPOINT [ "bash", "-c"]

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -52,3 +52,10 @@ BABEL_DEFAULT_TIMEZONE = 'Europe/Zurich'
 # I18N_LANGUAGES = [
 #     ('fr', _('French'))
 # ]
+
+
+# Invenio-Theme
+# =============
+# See https://invenio-theme.readthedocs.io/en/latest/configuration.html
+
+THEME_LOGO="images/logo.svg"


### PR DESCRIPTION
Changes:
- Does not copy the logo on the Dockerfile. Delegates to the collect/webpack build. This breaks the `update` command of the CLI see https://github.com/inveniosoftware/invenio-cli/issues/73.

Closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/26

@fenekku What is your take on it, shall we break `update` or keep it hardcoded for now and fix it for January?