### PR TITLE
[WIP]: dependencies: pin webargs to lower than 6.0.0

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -15,6 +15,7 @@ uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 lxml = "<4.2.6,>=3.5.0"
 marshmallow = "<3.0.0"
+webargs = "<6.0.0,>=5.5.0"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
Lack of pinning causes:

``` stacktrace
[2020-01-07 19:54:01,089] ERROR in app: Exception on /records/ [GET]
Traceback (most recent call last):
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask_restful/__init__.py", line 269, in error_router
    return original_handler(e)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/invenio_rest/views.py", line 240, in dispatch_request
    *args, **kwargs
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages/flask/views.py", line 163, in dispatch_request
    return meth(*args, **kwargs)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/invenio_records_rest/views.py", line 429, in need_record_permission_decorator
    return f(self, record=record, *args, **kwargs)
  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/invenio_records_rest/views.py", line 471, in inner
    error_status_code=400,
TypeError: parse() got an unexpected keyword argument 'locations'
[pid: 257|app: 1|req: 1/4] 172.18.0.1 () {58 vars in 954 bytes} [Tue Jan  7 19:54:01 2020] GET /api/records/?page=1&size=20&q= => generated 182 bytes in 86 msecs (HTTP/1.1 500) 15 headers in 709 bytes (1 switches on core 0)
```

The upper limit is not set in `invenio-rest`. I'd propose to **NOT** merge this until the next release is imminent and see whats the way to go on `invenio-rest`.

Reported by Dan and Kai. 