### PR TITLE
dependencies: limit werkzeug <1.0.0 [why]

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -15,6 +15,8 @@ uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 lxml = "<4.2.6,>=3.5.0"
 marshmallow = "<3.0.0"
+# werkzeug 1.0.0RC1 changes some import paths and breaks flask-babel
+werkzeug = "<1.0.0"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
Because we have to run pipenv install --pre until we move
to non-alpha versions, we are subject to the breaking changes
introduced by pre dependencies.

In this case, werkzeug 1.0.0RC1 changes the import of ImmutableDict:
from: `from werkzeug import ImmutableDict`
to: `from werkzeug.datastructures import ImmutableDict` which breaks
flask-babel, which breaks us.