### PR TITLE
Inveniocfg dockerfile

### DIFF
--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -42,25 +42,3 @@ check_ready "Redis" _redis_check
 
 _rabbit_check(){ docker-compose exec mq bash -c "rabbitmqctl status" &>/dev/null; }
 check_ready "RabbitMQ" _rabbit_check
-
-_web_server_check_css(){
-    string="Content-Type: text/css"
-    OUT=$(wget --spider -S -r -l 1 --page-requisites --no-check-certificate https://localhost 2>&1)
-    if echo $OUT | grep -q "$string"
-    then
-        return 0
-    else
-        return 1
-    fi
-}
-
-if [ "$1" == "--full" ]
-then
-    check_ready "CSS" _web_server_check_css
-
-    _web_server_check_http(){ curl --output /dev/null --silent --head --fail http://localhost:80 &>/dev/null; }
-    check_ready "Web Server HTTP" _web_server_check_http
-
-    _web_server_check_https(){ curl --output /dev/null --silent --head --fail -k https://localhost:443 &>/dev/null; }
-    check_ready "Web Server HTTPS" _web_server_check_https
-fi

--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -19,18 +19,13 @@
 # bootstrap script located in ./scripts/bootstrap.
 
 FROM inveniosoftware/centos7-python:3.6
+
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy --system
 
-COPY ./ .
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
 COPY ./templates/ ${INVENIO_INSTANCE_PATH}/templates/
-
-RUN invenio collect --verbose  && \
-    invenio webpack create && \
-    # --unsafe needed because we are running as root
-    invenio webpack install --unsafe && \
-    invenio webpack build
+COPY ./ .
 
 ENTRYPOINT [ "bash", "-c"]

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -7,6 +7,9 @@ For the full list of settings and their values, see
 https://invenio-app-rdm.readthedocs.io/en/latest/configuration.html
 and the config.py files of your installed modules
 https://invenio.readthedocs.io/en/latest/general/bundles.html
+
+Only configuration created via cookiecutter or very likely to be edited
+by installer are included here.
 """
 
 # Flask
@@ -32,6 +35,37 @@ SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://{{cookiecutter.project_shortname}
 {%- elif cookiecutter.database == 'mysql'%}
 SQLALCHEMY_DATABASE_URI="mysql+pymysql://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@localhost/{{cookiecutter.project_shortname}}"
 {%- endif %}
+
+
+# Invenio-App
+# ===========
+# See https://invenio-app.readthedocs.io/en/latest/configuration.html
+
+APP_DEFAULT_SECURE_HEADERS = {
+    'content_security_policy': {
+        'default-src': [
+            "'self'",
+            'fonts.googleapis.com',  # for fonts
+            '*.gstatic.com',    # for fonts
+            "'unsafe-inline'",  # for pdf preview
+            "blob:",            # for pdf preview
+            # Add your own policies here (e.g. analytics)
+        ],
+    },
+    'content_security_policy_report_only': False,
+    'content_security_policy_report_uri': None,
+    'force_file_save': False,
+    'force_https': True,
+    'force_https_permanent': False,
+    'frame_options': 'sameorigin',
+    'frame_options_allow_from': None,
+    'session_cookie_http_only': True,
+    'session_cookie_secure': True,
+    'strict_transport_security': True,
+    'strict_transport_security_include_subdomains': True,
+    'strict_transport_security_max_age': 31556926,  # One year in seconds
+    'strict_transport_security_preload': False,
+}
 
 
 # Flask-Babel

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -47,7 +47,7 @@ APP_DEFAULT_SECURE_HEADERS = {
             "'self'",
             'fonts.googleapis.com',  # for fonts
             '*.gstatic.com',    # for fonts
-            "'unsafe-inline'",  # for pdf preview
+            "'unsafe-inline'",  # for inline scripts and styles
             "blob:",            # for pdf preview
             # Add your own policies here (e.g. analytics)
         ],


### PR DESCRIPTION
Places relatively sane defaults for Content-Security-Policy
in invenio.cfg to allow pdfs preview + allow developers to
add their own after.

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/53

Removes webpack calls to create assets and statics bc
invenio-cli takes care of it:
  * don't want redundancy since expensive operation
  * invenio-cli takes care of it because it can
    then dynamically choose not to re-install JS
    dependencies: speeding it up further.