### PR TITLE
dependencies: update rdm packages, marshmallow, and werkzeug issues

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -7,16 +7,14 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "==1.0.0a5"}
-invenio-rdm-records = "==1.0.0a8"
-invenio-records-permissions = "==1.0.0a6"
+invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "==0.6.0"}
+invenio-rdm-records = "==0.9.0"
+invenio-records-permissions = "==0.7.0"
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 lxml = "<4.2.6,>=3.5.0"
-marshmallow = "<3.0.0"
-# werkzeug 1.0.0RC1 changes some import paths and breaks flask-babel
-werkzeug = "<1.0.0"
+marshmallow = ">=3.3.0,<4.0.0"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
Changes:

* Updates RDM packages
* Bump marshmallow
* Remove Werkzeug pin since it was fixed :)

Requries: https://github.com/inveniosoftware/invenio-rdm-records/pull/60
Requires: https://github.com/inveniosoftware/invenio-app-rdm/pull/77
Closes: https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/40