### PR TITLE
dependencies: make patch release compatible

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "~=0.6.1"}
+invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "~=0.6.2"}
 invenio-rdm-records = "~=0.9.0"
 invenio-records-permissions = "~=0.7.0"
 uwsgi = ">=2.0"

--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -7,9 +7,9 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "==0.6.0"}
-invenio-rdm-records = "==0.9.0"
-invenio-records-permissions = "==0.7.0"
+invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "~=0.6.1"}
+invenio-rdm-records = "~=0.9.0"
+invenio-records-permissions = "~=0.7.0"
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"


### PR DESCRIPTION
**WARNING**: Don't delete the branch when merging since we are using it in `invenio-cli`.

This change is an example of the web of dependency problem and a small-scale solution (and an example of a fortuitous workaround, but it's really a side note - see below):

Because we are strictly pinning (`==`) versions in the Pipfile of the cookiecutter, whenever a bugfix from another module is required, we need to change this file. Even then, if someone already ran the cookiecutter, they won't get that fix because their Pipfile is already cut.

What I suggest: loosen the version pinning in the Pipfile to at least allow patches, e.g.,:

 `invenio-rdm-records = "==0.9.0"` => `invenio-rdm-records = "~=0.9.0"`

A new monthly release would just bump the `X` in `"~=0.X.0"` (I think @slint mentioned something about compatible releases that I overlooked last time we talked about this, but I don't recall :sweat_smile: )  

*Side note: fortuitous workaround*

Because `invenio-cli` points to `v0.6.0` *branch*, we can just change the branch and leave everything else the same. Kind of nice, also kind of risky :man_shrugging:  