### PR TITLE
docker: add alt assets inclusion during build

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -17,11 +17,11 @@ pipfile_lock_path="./Pipfile.lock"
 
 if [ ! -f $pipfile_lock_path ]; then
     echo "'Pipfile.lock' not found. Generating via 'pipenv lock --dev'..."
-    pipenv lock --dev --pre
+    pipenv lock --dev
 fi
 
 # Installs all packages specified in Pipfile.lock
-pipenv sync --dev --pre
+pipenv sync --dev
 # Build assets
 pipenv run invenio collect -v
 pipenv run invenio webpack buildall

--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -25,20 +25,17 @@ ARG include_assets
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy --system
 
-COPY ./ .
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
 COPY ./templates/ ${INVENIO_INSTANCE_PATH}/templates/
+COPY ./ .
 
 RUN if [ "$include_assets" = "true" ]; \
     then \
         cp -r ./static/. ${INVENIO_INSTANCE_PATH}/static/ && \
         cp -r ./assets/. ${INVENIO_INSTANCE_PATH}/assets/ && \
         invenio collect --verbose  && \
-        invenio webpack create && \
-        # --unsafe needed because we are running as root
-        invenio webpack install --unsafe && \
-        invenio webpack build \
+        invenio webpack buildall \
     ; fi
 
 ENTRYPOINT [ "bash", "-c"]


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/54

Building the assets when running `containerize` is not desired since it is time consuming and it will happen twice. However, when deploying in the "cloud" they are needed. Therefore, this PR allows it conditionally. This way docker-compose will not pass the arg and `containerize` stays as is.

This is part of a bigger picture solution mentioned in the above issue.

**Method 1: flag the docker build and launch a job**

Since we do not want to incur into the "double building" of assets
(Once in the docker build, a second if updating). One option could
be to flag the building of assets in the Dockerfile (e.g. build only
if `include_assets` env var is True or is set).

Since as per docker documentation, when a volume is mounted the files of the folder (i.e. `/opt/...` of the web node) will be pass to the volume, giving access to them to the nginx.

Fixes on deployment and future todos can be found here: https://github.com/inveniosoftware/helm-invenio/pull/8