### PR TITLE
dockerfile: copy app_data/ folder

### DIFF
--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -28,6 +28,7 @@ RUN pipenv install --deploy --system
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
 COPY ./templates/ ${INVENIO_INSTANCE_PATH}/templates/
+COPY ./app_data/ ${INVENIO_INSTANCE_PATH}/app_data/
 COPY ./ .
 
 RUN if [ "$include_assets" = "true" ]; \

--- a/{{cookiecutter.project_shortname}}/app_data/README.md
+++ b/{{cookiecutter.project_shortname}}/app_data/README.md
@@ -1,0 +1,6 @@
+# README
+
+Place in this directory the subdirectories containing application data.
+
+For example, you can create the `vocabularies/` folder to hold
+your custom controlled vocabularies.


### PR DESCRIPTION
Adds a `app_data/` folder in the project to hold the custom application data files like vocabulary files (in `app_data/vocabularies`). This is general enough to hold all other cases of files holding application data.
   
Needed in particular for `invenio-cli containerize` to work with custom vocabulary.