### PR TITLE
dependencies: bump app-rdm and rdm-records for release 0.7.0

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -7,8 +7,8 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "~=0.6.2"}
-invenio-rdm-records = "~=0.9.0"
+invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"],version = "~=0.7.0"}
+invenio-rdm-records = "~=0.10.0"
 invenio-records-permissions = "~=0.7.0"
 {%- if cookiecutter.file_storage == 'S3'%}
 invenio-s3 = "~=1.0.2"


### PR DESCRIPTION
Requires https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/62
closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/63