### PR TITLE
config: load slugify extension and use for project_shortname

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "My Site",
-    "project_shortname": "{{ cookiecutter.project_name | lower | replace(' ', '-') }}",
+    "project_shortname": "{{ cookiecutter.project_name | slugify() }}",
     "project_site": "{{ cookiecutter.project_shortname }}.com",
     "github_repo": "{{ cookiecutter.project_shortname }}/{{ cookiecutter.project_shortname }}",
     "description": "Invenio RDM {{ cookiecutter.project_name }} Instance",


### PR DESCRIPTION
~~Requires: https://github.com/inveniosoftware/invenio-cli/pull/123~~ Comes from upstream cookiecutter.

Sample result:

```
% cookiecutter ../cookiecutter-invenio-rdm 
project_name [My Site]: Pablo's version
project_shortname [pablo-s-version]: 
project_site [pablo-s-version.com]: 
github_repo [pablo-s-version/pablo-s-version]: 
description [Invenio RDM Pablo's version Instance]: 
author_name [CERN]: 
author_email [info@pablo-s-version.com]: 
```

Closes: https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/45