### PR TITLE
dependencies: cap wtforms until fixed upstream

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -18,6 +18,7 @@ uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 lxml = "<4.2.6,>=3.5.0"
 marshmallow = ">=3.3.0,<4.0.0"
+wtforms = ">=2.2.0,<2.3.0"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
Until the WTForms [`email-validator` extra](https://github.com/wtforms/wtforms/pull/429) is installed upstream (https://github.com/lepture/flask-wtf and/or https://github.com/mattupstate/flask-security (don't know the status of that repo too much?)), we cap the version of wtforms so not to break.  
