### PR TITLE
dependencies: unpin wtforms

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -18,7 +18,6 @@ uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 lxml = "<4.2.6,>=3.5.0"
 marshmallow = ">=3.3.0,<4.0.0"
-wtforms = ">=2.2.0,<2.3.0"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/67

@fenekku `invenio-accounts` v1.2.1 and v1.1.4 have been released. Both include the `email-validator` dependency. According to our `invenio` dependency we should be in v1.1.4.