### PR TITLE
warnings_fix

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
@@ -24,15 +24,14 @@ server {
 
 # HTTPS server
 server {
-  listen 443; # IPv4
-  listen [::]:443; # IPv6
+  listen 443 ssl; # IPv4
+  listen [::]:443 ssl; # IPv6
   server_name _;
   charset utf-8;
   keepalive_timeout 5;
 
   # SSL configuration according to best practices from
   # https://mozilla.github.io/server-side-tls/ssl-config-generator/
-  ssl on;
   # The provided certificate (test.crt) and private key (test.key) is only for
   # testing and must never be used in production environment.
   ssl_certificate /etc/ssl/certs/test.crt;

--- a/{{cookiecutter.project_shortname}}/docker/nginx/nginx.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/nginx.conf
@@ -62,7 +62,6 @@ http {
         image/x-icon
         text/cache-manifest
         text/css
-        text/html
         text/javascript
         text/plain
         text/vcard


### PR DESCRIPTION
[Nginx_Warnings](https://github.com/inveniosoftware/invenio-app-rdm/issues/91)
According to nginx documentation, the ```ssl``` directive is deprecated and ```ssl on``` is no longer required.  ```listen 443 ssl``` is enough.
Also for the option ```gzip_types```, the mime-type ```text/html``` is always included by default, so no need to specify it explicitly.
