### PR TITLE
integrate invenio 3.4.0a1

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,6 +7,7 @@
     "author_name": "CERN",
     "author_email": "info@{{ cookiecutter.project_site }}",
     "year": "{% now 'local', '%Y' %}",
+    "python_version": ["3.6", "3.7", "3.8 (untested)"],
     "database": ["postgresql", "mysql", "sqlite"],
     "elasticsearch": ["7", "6"],
     "file_storage": ["local", "S3"]

--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -20,4 +20,4 @@ lxml = "<4.2.6,>=3.5.0"
 marshmallow = ">=3.3.0,<4.0.0"
 
 [requires]
-python_version = "3.6"
+python_version = "{{cookiecutter.python_version}}"

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -97,7 +97,8 @@ BABEL_DEFAULT_TIMEZONE = 'Europe/Zurich'
 # Frontpage title
 THEME_FRONTPAGE_TITLE = "{{ cookiecutter.project_name }}"
 # Header logo
-THEME_LOGO="images/logo.svg"
+# Coming from invenio-app-rdm
+THEME_LOGO = 'images/invenio-rdm.png'
 
 
 # Invenio-App-RDM


### PR DESCRIPTION
**Changes:**

- adds support for python 3.7 and 3.8 (untested)
- sets `THEME_LOGO` to that of InvenioRDM. This value is already set in `invenio-app-rdm` and would not be needed. However, for clarity to the user it is better to leave the variable in `invenio.cfg`.


Closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/71
Closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/64