### PR TITLE
Python 3.8 fixes

### DIFF
--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -8,7 +8,13 @@
 # Note: It is important to keep the commands in this file in sync with your
 # bootstrap script located in ./scripts/bootstrap.
 
+{% if cookiecutter.python_version.split()[0] == '3.6' -%}
 FROM inveniosoftware/centos7-python:3.6
+{%- elif cookiecutter.python_version.split()[0] == '3.7' -%}
+FROM inveniosoftware/centos7-python:3.7
+{%- elif cookiecutter.python_version.split()[0] == '3.8' -%}
+FROM inveniosoftware/centos8-python:3.8
+{%- endif %}
 
 ARG include_assets
 

--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -14,4 +14,4 @@ uwsgi-tools = ">=1.1.1"
 marshmallow = ">=3.3.0,<4.0.0"
 
 [requires]
-python_version = "{{cookiecutter.python_version}}"
+python_version = "{{ cookiecutter.python_version.split()[0] }}"


### PR DESCRIPTION
Here are two fixes so that the cookiecutter project will work once a Python 3.8 base docker image is published, as proposed in inveniosoftware/docker-invenio#32.