### PR TITLE
global: bump dependencies and add config [more]

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=0.11.1"}
+invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=0.12.0"}
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -127,3 +127,8 @@ APP_DEFAULT_SECURE_HEADERS['content_security_policy']['default-src'].append(
     S3_ENDPOINT_URL
 )
 {%- endif %}
+
+
+# Invenio-Records-Resources
+# =========================
+SERVER_HOSTNAME = "127.0.0.1:5000"


### PR DESCRIPTION
- Add SERVER_HOSTNAME to invenio.cfg in order to pass
  same origin policy

This is part of making a working August release and will be merged and deployed when it passes.