### PR TITLE
cookiecutter: make python 3.7 the default option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
     "author_name": "CERN",
     "author_email": "info@{{ cookiecutter.project_site }}",
     "year": "{% now 'local', '%Y' %}",
-    "python_version": ["3.6", "3.7", "3.8 (beta)"],
+    "python_version": ["3.7", "3.8 (beta)", "3.6"],
     "database": ["postgresql", "mysql", "sqlite"],
     "elasticsearch": ["7", "6"],
     "file_storage": ["local", "S3"]


### PR DESCRIPTION
- Makes 3.7 the default option. By default the first option is the default, and can only be overwritten with a [user config file](https://cookiecutter.readthedocs.io/en/1.7.2/advanced/choice_variables.html). Thus it seems the easiest simply to change the order.