### PR TITLE
celery:modify celery command.

### DIFF
--- a/scripts/server
+++ b/scripts/server
@@ -18,7 +18,7 @@ export FLASK_ENV=development
 export INVENIO_SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@localhost/{{cookiecutter.project_shortname}}"
 
 # Start Worker and Server
-pipenv run celery worker -A invenio_app.celery -l INFO & pid_celery=$!
+pipenv run celery -A invenio_app.celery worker -l INFO & pid_celery=$!
 
 pipenv run invenio run \
        --cert "$script_path"/../docker/nginx/test.crt \

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -110,7 +110,7 @@ services:
       file: docker-services.yml
       service: app
     restart: "always"
-    command: ["celery worker -A invenio_app.celery --loglevel=INFO"]
+    command: ["celery -A invenio_app.celery worker --loglevel=INFO"]
     image: {{cookiecutter.project_shortname}}
     depends_on:
       es:


### PR DESCRIPTION
With new Celery release ```5.0.1``` the commands are changed.
From ```celery worker [options]``` to ```celery [options] worker```. [CLI_ref](https://docs.celeryproject.org/en/stable/userguide/workers.html)