### PR TITLE
dependencies: cap sqlalchemy to ~=1.3.20

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -20,6 +20,7 @@ nbconvert = {extras = ["execute"], version = ">=4.1.0,<6.0.0"}
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
+sqlalchemy = "~=1.3.20"
 
 [requires]
 python_version = "{{ cookiecutter.python_version.split()[0] }}"


### PR DESCRIPTION
Quick fix for https://github.com/inveniosoftware/invenio-db/issues/141 .

I will also make a PR in invenio-db to make it more official.