### PR TITLE
docker-services: remove unused and change restart policy

### DIFF
--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -16,8 +16,6 @@ FROM inveniosoftware/centos8-python:3.7
 FROM inveniosoftware/centos8-python:3.8
 {%- endif %}
 
-ARG include_assets
-
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy --system --pre
 

--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -27,14 +27,11 @@ COPY ./templates/ ${INVENIO_INSTANCE_PATH}/templates/
 COPY ./app_data/ ${INVENIO_INSTANCE_PATH}/app_data/
 COPY ./ .
 
-RUN if [ "$include_assets" = "true" ]; \
-    then \
-        cp -r ./static/. ${INVENIO_INSTANCE_PATH}/static/ && \
-        cp -r ./assets/. ${INVENIO_INSTANCE_PATH}/assets/ && \
-        invenio collect --verbose  && \
-        invenio webpack create && \
-        invenio webpack install --unsafe && \
-        invenio webpack build \
-    ; fi
+RUN cp -r ./static/. ${INVENIO_INSTANCE_PATH}/static/ && \
+    cp -r ./assets/. ${INVENIO_INSTANCE_PATH}/assets/ && \
+    invenio collect --verbose  && \
+    invenio webpack create && \
+    invenio webpack install --unsafe && \
+    invenio webpack build
 
 ENTRYPOINT [ "bash", "-c"]

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -71,15 +71,6 @@ services:
       - uploaded_data:/opt/invenio/var/instance/data
       - archived_data:/opt/invenio/var/instance/archive
       {%- endif %}
-    depends_on:
-      es:
-        condition: service_started
-      cache:
-        condition: service_started
-      db:
-        condition: service_started
-      mq:
-        condition: service_started
 
   # API Rest Application
   web-api:
@@ -95,15 +86,7 @@ services:
       - uploaded_data:/opt/invenio/var/instance/data
       - archived_data:/opt/invenio/var/instance/archive
     {%- endif %}
-    depends_on:
-      es:
-        condition: service_started
-      cache:
-        condition: service_started
-      db:
-        condition: service_started
-      mq:
-        condition: service_started
+
   # Worker
   worker:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -22,31 +22,23 @@ services:
       {%- endif %}
       - "INVENIO_WSGI_PROXIES=2"
       - "INVENIO_RATELIMIT_STORAGE_URL=redis://cache:6379/3"
-  lb:
-    build: ./docker/haproxy/
-    image: {{cookiecutter.project_shortname}}-lb
-    restart: "always"
-    ports:
-      - "80:80"
-      - "443:443"
-      - "8080:8080"
   frontend:
     build: ./docker/nginx/
     image: {{cookiecutter.project_shortname}}-frontend
-    restart: "always"
+    restart: "unless-stopped"
     ports:
       - "80"
       - "443"
   cache:
     image: redis
-    restart: "always"
+    restart: "unless-stopped"
     read_only: true
     ports:
       - "6379:6379"
   db:
     {%- if cookiecutter.database == 'postgresql'%}
     image: postgres:12.4
-    restart: "always"
+    restart: "unless-stopped"
     environment:
       - "POSTGRES_USER={{cookiecutter.project_shortname}}"
       - "POSTGRES_PASSWORD={{cookiecutter.project_shortname}}"
@@ -55,7 +47,7 @@ services:
       - "5432:5432"
     {%- elif cookiecutter.database == 'mysql'%}
     image: mysql
-    restart: "always"
+    restart: "unless-stopped"
     environment:
       - "MYSQL_ROOT_PASSWORD={{cookiecutter.project_shortname}}"
       - "MYSQL_DATABAE={{cookiecutter.project_shortname}}"
@@ -66,7 +58,7 @@ services:
     {%- endif %}
   mq:
     image: rabbitmq:3-management
-    restart: "always"
+    restart: "unless-stopped"
     ports:
       - "15672:15672"
       - "5672:5672"
@@ -76,7 +68,7 @@ services:
     {%- elif cookiecutter.elasticsearch == '6' %}
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.9
     {%- endif %}
-    restart: "always"
+    restart: "unless-stopped"
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -94,26 +86,10 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
-  kibana:
-    {%- if cookiecutter.elasticsearch == '7'%}
-    image: docker.elastic.co/kibana/kibana-oss:7.9.3
-    {%- elif cookiecutter.elasticsearch == '6' %}
-    image: docker.elastic.co/kibana/kibana-oss:6.8.9
-    {%- endif %}
-    environment:
-      - "ELASTICSEARCH_HOSTS=http://es:9200"
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ports:
-      - "5601:5601"
-  flower:
-    image: mher/flower
-    command: --broker=amqp://guest:guest@mq:5672/ --broker_api=http://guest:guest@mq:15672/api/
-    ports:
-      - "5555:5555"
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     image: minio/minio
-    restart: "always"
+    restart: "unless-stopped"
     ports:
       - "9000:9000"
     environment:


### PR DESCRIPTION
Related to https://github.com/inveniosoftware/docker-services-cli/pull/13

**Changes**

- Change the restart: always from docker-services.yml in Cookiecutter-Invenio-RDM. Might need another pass when a decision is taken in inveniosoftware/docker-services-cli#13
- Remove unused services from docker-services.yml: flower, kibana, lb. Some of them like `lb` were even missing files (haproxy docker file) and resulting in  errors upon `docker-compose exec` commands.

