### PR TITLE
docker-compose: add restart policy for app

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -6,6 +6,7 @@ services:
       args:
         - ENVIRONMENT=DEV
     image: {{cookiecutter.project_shortname}}
+    restart: "unless-stopped"
     environment:
       - "INVENIO_ACCOUNTS_SESSION_REDIS_URL=redis://cache:6379/1"
       - "INVENIO_BROKER_URL=amqp://guest:guest@mq:5672/"


### PR DESCRIPTION
There is a restart policy for other services. Why not for app? ¯\_(ツ)_/¯