### PR TITLE
uwsgi: fix occasional 502 by boosting buffer-size [+]

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_rest.ini
+++ b/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_rest.ini
@@ -10,3 +10,4 @@ mount = /api=invenio_app.wsgi_rest:application
 manage-script-name = true
 wsgi-disable-file-wrapper = true
 single-interpreter = true
+buffer-size = 8192

--- a/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_ui.ini
+++ b/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_ui.ini
@@ -7,3 +7,4 @@ die-on-term = true
 processes = 2
 threads = 2
 single-interpreter = true
+buffer-size = 8192


### PR DESCRIPTION
For the longest time, the default installation at Northwestern
would return 502s to some people at some times... Turns out that
headers larger than 4096 bytes were sometimes generated causing
uwsgi to drop the request. While not going overboard, this does
give us some room to spare for larger headers.

I am sharing the fix here, because we are probably not the only ones 
that would experience this with an out of the gate install.