### PR TITLE
dependencies: use invenio 3.4

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -9,14 +9,13 @@ check-manifest = ">=0.25"
 [packages]
 flask-resources = "~=0.3.2"
 importlib-metadata = ">=0.12,<2.0.0"
-invenio = "~=3.4.0rc1"
-invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=0.18.0"}
+invenio = "~=3.4.0"
+invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=0.18.2"}
 invenio-drafts-resources = "~=0.7.1"
-invenio-rdm-records = "~=0.25.0"
+invenio-rdm-records = "~=0.25.5"
 invenio-records-permissions = "~=0.10.0"
-invenio-records-resources = "~=0.9.2"
+invenio-records-resources = "~=0.9.5"
 marshmallow-utils = "~=0.3.2"
-nbconvert = {extras = ["execute"], version = ">=4.1.0,<6.0.0"}
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"


### PR DESCRIPTION
- Invenio 3.4
- Update RDM patch versions
- Remove nbconvert since it was capped in invenio-previewer