### PR TITLE
dependency: bump for flask-resources

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 check-manifest = ">=0.25"
 
 [packages]
-flask-resources = "~=0.3.2"
+flask-resources = "~=0.4.0"
 importlib-metadata = ">=0.12,<2.0.0"
 invenio = "~=3.4.0"
 invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=0.18.2"}


### PR DESCRIPTION
Resolves dependency conflict see below:
```bash
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  First try clearing your dependency cache with $ pipenv lock --clear, then try the original command again.
 Alternatively, you can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: Could not find a version that matches flask-resources<1.0.0,>=0.4.0,~=0.3.2 (from -r /tmp/pipenv28jvo9z_requirements/pipenv-uezwzxx4-constraints.txt (line 10))
Tried: 0.1.0, 0.1.0, 0.2.0, 0.2.0, 0.2.1, 0.2.1, 0.2.2, 0.2.2, 0.3.0, 0.3.0, 0.3.1, 0.3.1, 0.3.2, 0.3.2, 0.3.3, 0.3.3, 0.4.0, 0.4.0
There are incompatible versions in the resolved dependencies:
  flask-resources~=0.3.2 (from -r /tmp/pipenv28jvo9z_requirements/pipenv-uezwzxx4-constraints.txt (line 10))
  flask-resources<1.0.0,>=0.4.0 (from invenio-records-resources==0.9.7->-r /tmp/pipenv28jvo9z_requirements/pipenv-uezwzxx4-constraints.txt (line 9))
``` 
