### PR TITLE
docker: add kibana and flower

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -16,6 +16,8 @@
 # - DB: (PostgresSQL/MySQL) (exposed port: 5432 or 3306)
 # - Message queue: RabbitMQ (exposed ports: 5672, 15672)
 # - Elasticsearch (exposed ports: 9200, 9300)
+# - Kibana (view ES indexes) (exposed ports: 5601)
+# - Flower (monitor Celery task) (exposed ports: 5555)
 #
 version: '2.2'
 services:
@@ -37,6 +39,14 @@ services:
     extends:
       file: docker-services.yml
       service: es
+  kibana:
+    extends:
+      file: docker-services.yml
+      service: kibana
+  flower:
+    extends:
+      file: docker-services.yml
+      service: flower
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-compose.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.yml
@@ -12,6 +12,8 @@
 # - DB: (PostgresSQL/MySQL) (exposed port: 5432 or 3306)
 # - Message queue: RabbitMQ (exposed ports: 5672, 15672)
 # - Elasticsearch (exposed ports: 9200, 9300)
+# - Kibana (view ES indexes) (exposed ports: 5601)
+# - Flower (monitor Celery task) (exposed ports: 5555)
 #
 version: '2.2'
 services:
@@ -33,6 +35,14 @@ services:
     extends:
       file: docker-services.yml
       service: es
+  kibana:
+    extends:
+      file: docker-services.yml
+      service: kibana
+  flower:
+    extends:
+      file: docker-services.yml
+      service: flower
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -64,10 +64,10 @@ services:
       - "15672:15672"
       - "5672:5672"
   es:
-    {%- if cookiecutter.elasticsearch == '7' %}
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
+    {%- if cookiecutter.elasticsearch == '7' %}{# Do not update to 7.11 #}
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     {%- elif cookiecutter.elasticsearch == '6' %}
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.9
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.14
     {%- endif %}
     restart: "unless-stopped"
     environment:
@@ -87,6 +87,22 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
+  kibana:
+    {%- if cookiecutter.elasticsearch == '7'%}{# Do not update to 7.11 #}
+    image: docker.elastic.co/kibana/kibana-oss:7.10.2
+    {%- elif cookiecutter.elasticsearch == '6' %}
+    image: docker.elastic.co/kibana/kibana-oss:6.8.14
+    {%- endif %}
+    environment:
+      - "ELASTICSEARCH_HOSTS=http://es:9200"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "5601:5601"
+  flower:
+    image: mher/flower
+    command: --broker=amqp://guest:guest@mq:5672/ --broker_api=http://guest:guest@mq:15672/api/
+    ports:
+      - "5555:5555"
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     image: minio/minio


### PR DESCRIPTION
* Adds Kibana for developers to easily inspect search indices.

* Adds Flower for Celery monitoring to easily inspect celery task
  execution.

Cookiecutter should ask if the user wants these services or not.