### PR TITLE
Remove sqlite as an option and related conditional blocks

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,7 @@
     "author_email": "info@{{ cookiecutter.project_site }}",
     "year": "{% now 'local', '%Y' %}",
     "python_version": ["3.8", "3.7", "3.6", "3.9 (alpha)"],
-    "database": ["postgresql", "mysql", "sqlite"],
+    "database": ["postgresql", "mysql"],
     "elasticsearch": ["7", "6"],
     "file_storage": ["local", "S3"]
 }

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -23,12 +23,10 @@ services:
     extends:
       file: docker-services.yml
       service: cache
-{%- if cookiecutter.database != 'sqlite'%}
   db:
     extends:
       file: docker-services.yml
       service: db
-{%- endif %}
   mq:
     extends:
       file: docker-services.yml

--- a/{{cookiecutter.project_shortname}}/docker-compose.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.yml
@@ -19,12 +19,10 @@ services:
     extends:
       file: docker-services.yml
       service: cache
-{%- if cookiecutter.database != 'sqlite'%}
   db:
     extends:
       file: docker-services.yml
       service: db
-{%- endif %}
   mq:
     extends:
       file: docker-services.yml


### PR DESCRIPTION
As per https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/16 removes sqlite as offered  db option and removes the conditional blocks in the templates that checked for sqlite.