### PR TITLE
dockerfile: install dejavu fonts for doi badge

### DIFF
--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -16,6 +16,8 @@ FROM inveniosoftware/centos8-python:3.7
 FROM inveniosoftware/centos8-python:3.8
 {%- endif %}
 
+RUN yum install -y dejavu-sans-fonts
+
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy --system --pre
 


### PR DESCRIPTION
this would ideally be added in the invenio base image, but is causing troubles with the way we install Python, see PR https://github.com/inveniosoftware/docker-invenio/pull/40, it will require more time.