### PR TITLE
setup: create S3 bucket from preexisting directory

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -19,3 +19,7 @@ openssl req -x509 -newkey rsa:4096 -nodes -out docker/nginx/test.crt -keyout doc
 
 echo "-------------------------------------------------------------------------------"
 
+{%- if cookiecutter.file_storage == 'S3' %}
+mkdir -p data/default
+touch data/default/.gitkeep
+{%- endif %}

--- a/scripts/setup
+++ b/scripts/setup
@@ -6,6 +6,7 @@
 #
 # Copyright (C) 2019 CERN.
 # Copyright (C) 2019 Northwestern University.
+# Copyright (C) 2021 Esteban J. G. Gabancho.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -27,8 +28,7 @@ pipenv run invenio index init --force
 pipenv run invenio index queue init purge
 if [ $COOKIECUTTER_FILE_STORAGE -eq "S3" ]
 then
-docker-compose exec s3 bash -c "mc mb default-bucket" &>/dev/null;
-pipenv run invenio files location s3-default s3://default-bucket --default
+pipenv run invenio files location s3-default s3://default --default
 else
 pipenv run invenio files location --default 'default-location'  $(pipenv run invenio shell --no-term-title -c "print(app.instance_path)")
 fi

--- a/{{cookiecutter.project_shortname}}/.gitignore
+++ b/{{cookiecutter.project_shortname}}/.gitignore
@@ -66,3 +66,7 @@ logs/
 
 # Invenio-cli per machine file
 .invenio.private
+
+# S3 default bucket location
+data/default/*
+data/.minio.sys

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -126,6 +126,6 @@ services:
       MINIO_ACCESS_KEY: CHANGE_ME
       MINIO_SECRET_KEY: CHANGE_ME
     volumes:
-      - data:/data
+      - ./data:/data
     command: server /data
 {%- endif %}


### PR DESCRIPTION
* When using S3 (min.io) for local testing, create a directory that will
  be used as default bucket for the files location instead of creating a
  bucket programmatically with ``mc``. (closes #53)