### PR TITLE
docker-compose: make worker restart policy same as others

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -90,7 +90,6 @@ services:
     extends:
       file: docker-services.yml
       service: app
-    restart: "always"
     command: ["celery -A invenio_app.celery worker --loglevel=INFO"]
     image: {{cookiecutter.project_shortname}}
     depends_on:


### PR DESCRIPTION
restart: unless-stopped is a bit more UX friendly than always

fixes an issue raised by chriz on discord