### PR TITLE
dockerfile: remove imagemagick dependency

### DIFF
--- a/{{cookiecutter.project_shortname}}/Dockerfile
+++ b/{{cookiecutter.project_shortname}}/Dockerfile
@@ -16,8 +16,6 @@ FROM inveniosoftware/centos8-python:3.7
 FROM inveniosoftware/centos8-python:3.8
 {%- endif %}
 
-RUN yum install -y ImageMagick
-
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy --system --pre
 


### PR DESCRIPTION
closes #162 

`ImageMagick` dependency has been moved to the inveniosoftware base image https://github.com/inveniosoftware/docker-invenio/pull/45