### PR TITLE
global: add development services

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,5 +10,6 @@
     "python_version": ["3.8", "3.7", "3.6", "3.9 (alpha)"],
     "database": ["postgresql", "mysql"],
     "elasticsearch": ["7", "6"],
-    "file_storage": ["local", "S3"]
+    "file_storage": ["local", "S3"],
+    "development_tools": ["yes", "no"]
 }

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -37,6 +37,7 @@ services:
     extends:
       file: docker-services.yml
       service: es
+{%- if cookiecutter.development_tools == 'yes'%}
   kibana:
     extends:
       file: docker-services.yml
@@ -45,6 +46,18 @@ services:
     extends:
       file: docker-services.yml
       service: flower
+  {%- if cookiecutter.database == 'postgresql'%}
+  pgadmin:
+    extends:
+      file: docker-services.yml
+      service: pgadmin
+  {%- elif cookiecutter.database == 'mysql'%}
+  phpmyadmin:
+    extends:
+      file: docker-services.yml
+      service: phpmyadmin
+  {%- endif %}
+{%- endif %}
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -16,6 +16,8 @@
 # - DB: (PostgresSQL/MySQL) (exposed port: 5432 or 3306)
 # - Message queue: RabbitMQ (exposed ports: 5672, 15672)
 # - Elasticsearch (exposed ports: 9200, 9300)
+# - Kibana (view ES indexes) (exposed ports: 5601)
+# - Flower (monitor Celery task) (exposed ports: 5555)
 #
 version: '2.2'
 services:
@@ -35,6 +37,14 @@ services:
     extends:
       file: docker-services.yml
       service: es
+  kibana:
+    extends:
+      file: docker-services.yml
+      service: kibana
+  flower:
+    extends:
+      file: docker-services.yml
+      service: flower
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-compose.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.yml
@@ -12,6 +12,8 @@
 # - DB: (PostgresSQL/MySQL) (exposed port: 5432 or 3306)
 # - Message queue: RabbitMQ (exposed ports: 5672, 15672)
 # - Elasticsearch (exposed ports: 9200, 9300)
+# - Kibana (view ES indexes) (exposed ports: 5601)
+# - Flower (monitor Celery task) (exposed ports: 5555)
 #
 version: '2.2'
 services:
@@ -31,6 +33,14 @@ services:
     extends:
       file: docker-services.yml
       service: es
+  kibana:
+    extends:
+      file: docker-services.yml
+      service: kibana
+  flower:
+    extends:
+      file: docker-services.yml
+      service: flower
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-compose.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     extends:
       file: docker-services.yml
       service: es
+{%- if cookiecutter.development_tools == 'yes'%}
   kibana:
     extends:
       file: docker-services.yml
@@ -41,6 +42,18 @@ services:
     extends:
       file: docker-services.yml
       service: flower
+  {%- if cookiecutter.database == 'postgresql'%}
+  pgadmin:
+    extends:
+      file: docker-services.yml
+      service: pgadmin
+  {%- elif cookiecutter.database == 'mysql'%}
+  phpmyadmin:
+    extends:
+      file: docker-services.yml
+      service: phpmyadmin
+  {%- endif %}
+{%- endif %}
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -36,8 +36,8 @@ services:
     read_only: true
     ports:
       - "6379:6379"
+  {%- if cookiecutter.database == 'postgresql'%}
   db:
-    {%- if cookiecutter.database == 'postgresql'%}
     image: postgres:12.4
     restart: "unless-stopped"
     environment:
@@ -46,7 +46,17 @@ services:
       - "POSTGRES_DB={{cookiecutter.project_shortname}}"
     ports:
       - "5432:5432"
-    {%- elif cookiecutter.database == 'mysql'%}
+  pgadmin:
+    image: dpage/pgadmin4:5.2
+    restart: "unless-stopped"
+    ports:
+      - "5050:80"
+      - "5051:443"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "{{cookiecutter.author_email}}"
+      PGADMIN_DEFAULT_PASSWORD: "{{cookiecutter.project_shortname}}"
+  {%- elif cookiecutter.database == 'mysql'%}
+  db:
     image: mysql
     restart: "unless-stopped"
     environment:
@@ -56,7 +66,15 @@ services:
       - "MYSQL_PASSWORD={{cookiecutter.project_shortname}}"
     ports:
       - "3306:3306"
-    {%- endif %}
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    restart: "unless-stopped"
+    ports:
+      - '8080:80'
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: {{cookiecutter.project_shortname}}
+  {%- endif %}
   mq:
     image: rabbitmq:3.8-management
     restart: "unless-stopped"

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -64,10 +64,10 @@ services:
       - "15672:15672"
       - "5672:5672"
   es:
-    {%- if cookiecutter.elasticsearch == '7' %}
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
+    {%- if cookiecutter.elasticsearch == '7' %}{# Do not update to 7.11 #}
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
     {%- elif cookiecutter.elasticsearch == '6' %}
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.9
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.14
     {%- endif %}
     restart: "unless-stopped"
     environment:
@@ -87,6 +87,22 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
+  kibana:
+    {%- if cookiecutter.elasticsearch == '7'%}{# Do not update to 7.11 #}
+    image: docker.elastic.co/kibana/kibana-oss:7.10.2
+    {%- elif cookiecutter.elasticsearch == '6' %}
+    image: docker.elastic.co/kibana/kibana-oss:6.8.14
+    {%- endif %}
+    environment:
+      - "ELASTICSEARCH_HOSTS=http://es:9200"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "5601:5601"
+  flower:
+    image: mher/flower
+    command: --broker=amqp://guest:guest@mq:5672/ --broker_api=http://guest:guest@mq:15672/api/
+    ports:
+      - "5555:5555"
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
     image: minio/minio


### PR DESCRIPTION
closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/126

**Important note**: PgAdmin requires `db` as host name to connect properly

screenshots (pgadmin, phpmyadmin, flower, kibana)

![Screenshot 2021-06-14 at 15 11 13](https://user-images.githubusercontent.com/6756943/121898022-3f087380-cd23-11eb-9405-3bbaf6a81806.png)
![Screenshot 2021-06-14 at 15 50 54](https://user-images.githubusercontent.com/6756943/121903222-5f86fc80-cd28-11eb-80ad-4fee2faa8001.png)
![Screenshot 2021-06-14 at 14 35 02](https://user-images.githubusercontent.com/6756943/121898034-416acd80-cd23-11eb-8f32-6f6b1b876799.png)
![Screenshot 2021-06-14 at 14 34 46](https://user-images.githubusercontent.com/6756943/121898037-429bfa80-cd23-11eb-9933-4ba93ba0362b.png)
