### PR TITLE
fixtures: add affiliations data

### DIFF
--- a/{{cookiecutter.project_shortname}}/app_data/vocabularies.yaml
+++ b/{{cookiecutter.project_shortname}}/app_data/vocabularies.yaml
@@ -6,3 +6,11 @@
 #       name: Default demo example subjects
 #       uri: "https://inveniosoftware.org/products/rdm/"
 #       data-file: vocabularies/subjects_default.yaml
+# TODO: Uncoment this if you want to have all affiliations with ROR identifiers.
+# affiliations:
+#   pid-type: aff
+#   schemes:
+#     - id: ROR
+#       name: Research Organization Registry
+#       uri: "https://ror.org/"
+#       data-file: vocabularies/affiliations_ror.yaml


### PR DESCRIPTION
Used this gist to produce the file https://gist.github.com/ppanero/ef9848e848de16bdb280ef5209f4c6fa

Commenting out the external ids due to scheme support

Adds approximately 100K affiliations... And still indexing new ones... The background creation for the first `invenio-cli run` is quite slow ~12-15mins)

Suggestions take between 2-3 seconds... but they appear:

<img width="955" alt="Screenshot 2021-07-22 at 15 56 04" src="https://user-images.githubusercontent.com/6756943/126651321-4d662940-f672-4758-adcf-711837ff3765.png">
<img width="952" alt="Screenshot 2021-07-22 at 15 55 58" src="https://user-images.githubusercontent.com/6756943/126651326-9d5311ec-f67e-40ce-bdf5-b5b5536d27c4.png">
<img width="966" alt="Screenshot 2021-07-22 at 15 55 47" src="https://user-images.githubusercontent.com/6756943/126651329-bf767f8d-bb9e-4637-821d-c0382062cca1.png">
