### PR TITLE
config: set default preview image size limit to 5mb

### DIFF
--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -182,3 +182,7 @@ OAUTHCLIENT_AUTO_REDIRECT_TO_EXTERNAL_LOGIN = False  # autoredirect to external 
 # Invenio-UserProfiles
 # --------------------
 USERPROFILES_READ_ONLY = False  # allow users to change profile info (name, email, etc...)
+
+# Invenio-Previewer
+# -----------------
+PREVIEWER_MAX_IMAGE_SIZE_BYTES = 0.5 * 1024 * 1024 * 1024  # 5MB


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/179

**Open Questions**
While we do not have IIIF or any better performing previewer... is 5 MB a sensible limit? before it was set to 500KB, which was making it fail for mostly every file.


**IMPORTANT NOTE**: Remember to merge this commit also to v5 branch for it to be included in the release.