### PR TITLE
services: configure secrets/user for minio (s3)

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -122,10 +122,16 @@ services:
     restart: "unless-stopped"
     ports:
       - "9000:9000"
+      - "9001:9001"
     environment:
-      MINIO_ACCESS_KEY: CHANGE_ME
-      MINIO_SECRET_KEY: CHANGE_ME
+      MINIO_ROOT_USER: CHANGE_ME
+      MINIO_ROOT_PASSWORD: CHANGE_ME
     volumes:
       - ./data:/data
-    command: server /data
+    command: server /data --console-address :9001
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
 {%- endif %}


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1031

File upload:
<img width="1240" alt="Screenshot 2021-08-02 at 15 46 14" src="https://user-images.githubusercontent.com/6756943/127872309-9a794418-a985-47cd-b3e1-73b380f401f1.png">

File preview:
<img width="830" alt="Screenshot 2021-08-02 at 15 46 27" src="https://user-images.githubusercontent.com/6756943/127872306-e57040e6-6076-4a49-947a-6229b19df024.png">

Object in minio:
![Screenshot 2021-08-02 at 15 47 46](https://user-images.githubusercontent.com/6756943/127872302-1b6156d2-0bf2-49f3-9a12-336e8e1052c1.png)

