### PR TITLE
compose: build instance/app image only once

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -78,7 +78,7 @@ services:
       file: docker-services.yml
       service: app
     command: ["uwsgi /opt/invenio/var/instance/uwsgi_ui.ini"]
-    image: {{cookiecutter.project_shortname}}
+    image: {{cookiecutter.project_shortname}}:latest
     ports:
       - "5000"
     volumes:
@@ -94,7 +94,7 @@ services:
       file: docker-services.yml
       service: app
     command: ["uwsgi /opt/invenio/var/instance/uwsgi_rest.ini"]
-    image: {{cookiecutter.project_shortname}}
+    image: {{cookiecutter.project_shortname}}:latest
     ports:
       - "5000"
     {%- if cookiecutter.file_storage == 'local'%}
@@ -109,7 +109,7 @@ services:
       file: docker-services.yml
       service: app
     command: ["celery -A invenio_app.celery worker --loglevel=INFO"]
-    image: {{cookiecutter.project_shortname}}
+    image: {{cookiecutter.project_shortname}}:latest
     depends_on:
       es:
         condition: service_started


### PR DESCRIPTION
Since there was no tag, the image was build for every service that uses it (web-api, web-ui and worker), beeing cached only until the webpack part.