### PR TITLE
global: skip ipython 8.1.0

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -10,6 +10,7 @@ setuptools = ">=59.1.1,<59.7.0"
 
 [packages]
 invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=8.0.0.dev3"}
+ipython = "!=8.1.0"
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"


### PR DESCRIPTION
* ipython 8.1.0 introduced an issue when running python<3.9