### PR TITLE
global: remove python 3.6 as an install option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,7 @@
     "author_name": "CERN",
     "author_email": "info@{{ cookiecutter.project_site }}",
     "year": "{% now 'local', '%Y' %}",
-    "python_version": ["3.8", "3.7", "3.6", "3.9"],
+    "python_version": ["3.8", "3.7", "3.9"],
     "database": ["postgresql"],
     "elasticsearch": ["7", "6"],
     "file_storage": ["local", "S3"],


### PR DESCRIPTION
* Python 3.6 have reached end-of-life and is no longer supported
  by the Python foundation.

