### PR TITLE
remove ipython and setuptools restriction

### DIFF
--- a/{{cookiecutter.project_shortname}}/Pipfile
+++ b/{{cookiecutter.project_shortname}}/Pipfile
@@ -5,12 +5,9 @@ verify_ssl = true
 
 [dev-packages]
 check-manifest = ">=0.25"
-# REMOVE setuptools line once celery 5.2.4 has been released.
-setuptools = ">=59.1.1,<59.7.0"
 
 [packages]
 invenio-app-rdm = {extras = ["{{ cookiecutter.database }}", "elasticsearch{{cookiecutter.elasticsearch}}"{% if cookiecutter.file_storage == 'S3' %}, "s3"{% endif %}], version = "~=9.0.0.dev7"}
-ipython = "!=8.1.0"
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"


### PR DESCRIPTION
celery 5.2.4 got released (latests 5.2.6) and also ipython 8.2.0.

Tried installing with invenio-app-rdm 9.0.0.dev11 and it worked (took 2 minutes):

```
🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 214/214 — 00:02:27
```

Also removing the setuptools pin shows a deprecation warning that might hit us later on...

```
/.../instance-members/lib/python3.8/site-packages/setuptools/config/__init__.py:28: SetuptoolsDeprecationWarning: As setuptools moves its configuration towards `pyproject.toml`,
`setuptools.config.read_configuration` became deprecated.
For the time being, you can use the `setuptools.config.setupcfg` module
to access a backward compatible API, but this module is provisional
and might be removed in the future.
  warnings.warn(dedent(msg), SetuptoolsDeprecationWarning)
```