### PR TITLE
config: add default value for caching max_age

### DIFF
--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -14,6 +14,12 @@ from flask_babelex import lazy_gettext as _
 # =====
 # See https://flask.palletsprojects.com/en/1.1.x/config/
 
+# Define the value of the cache control header `max-age` returned by the server when serving
+# public files. Files will be cached by the browser for the provided number of seconds.
+# See flask documentation for more information:
+# https://flask.palletsprojects.com/en/2.1.x/config/#SEND_FILE_MAX_AGE_DEFAULT
+SEND_FILE_MAX_AGE_DEFAULT = 300
+
 # SECURITY WARNING: keep the secret key used in production secret!
 # Do not commit it to a source code repository.
 # TODO: Set


### PR DESCRIPTION
set a default value for the flask variable `SEND_FILE_MAX_AGE_DEFAULT` 

partly closes https://github.com/inveniosoftware/invenio-communities/issues/718

