### PR TITLE
config: prefix indices

### DIFF
--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -203,3 +203,8 @@ USERPROFILES_READ_ONLY = False  # allow users to change profile info (name, emai
 
 OAISERVER_ID_PREFIX = "{{ cookiecutter.project_site }}"
 """The prefix that will be applied to the generated OAI-PMH ids."""
+
+# Invenio-Search
+# --------------
+
+SEARCH_INDEX_PREFIX = "{{cookiecutter.project_shortname}}-"


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/cookiecutter-invenio-rdm/issues/227

When deploying the demo site in QA for custom fields. I realized that it did not supported prefixed indices (happened also in the previous release... To avoid noticing this at deploy time, we can add the prefix to every instance (it has no impact on the end user). 

P.S. Approved by Lars