### PR TITLE
uwsgi: disable file wrapper causing issues

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_ui.ini
+++ b/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_ui.ini
@@ -8,3 +8,4 @@ processes = 2
 threads = 2
 single-interpreter = true
 buffer-size = 8192
+wsgi-disable-file-wrapper = true


### PR DESCRIPTION
The uWSGI UI application server is in charge of serving files. Without this setting serving large files was failing for us, ergo it might be useful for others. The option is already used in the uWSGI API application server. See https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html?highlight=wsgi-disable-file-wrapper#things-to-know-best-practices-and-issues-read-it for more details.