### PR TITLE
docker: pin minio version to avoid fs errors

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -152,7 +152,7 @@ services:
   {%- endif %}
 {%- if cookiecutter.file_storage == 'S3'%}
   s3:
-    image: minio/minio
+    image: minio/minio:RELEASE.2022-10-24T18-35-07Z
     restart: "unless-stopped"
     ports:
       - "9000:9000"


### PR DESCRIPTION
Newer versions of Minio drop support for MinIO Gateway and the related filesystem mode. 
From the documentation (https://min.io/docs/minio/linux/operations/install-deploy-manage/migrate-fs-gateway.html)

> Deployments still using the standalone or filesystem MinIO modes that upgrade to [RELEASE.2022-10-29T06-21-33Z](https://github.com/minio/minio/releases/tag/RELEASE.2022-10-29T06-21-33Z) or later receive an error when attempting to start MinIO. 
> 
> Important
> 
> Standalone/file system mode continues to work on any release up to and including [RELEASE.2022-10-24T18-35-07Z](https://github.com/minio/minio/releases/tag/RELEASE.2022-10-24T18-35-07Z). To continue using a standalone deployment, install that MinIO release or any [earlier release](https://github.com/minio/minio/releases).

If someone has a better solution, I'll be happy to check it out.