### PR TITLE
vocabularies: chase change in rdm-records fixtures command

### DIFF
--- a/{{cookiecutter.project_shortname}}/app_data/vocabularies.yaml
+++ b/{{cookiecutter.project_shortname}}/app_data/vocabularies.yaml
@@ -5,7 +5,7 @@ subjects:
       name: Fields of Science and Technology
       uri: "http://www.oecd.org/science/inno/38235147.pdf"
       data-file: vocabularies/subjects_oecd_fos.yaml
-# Minimimal example vocabularies
+# Minimal example vocabularies
 # can be used for quick testing, or a basis for building your own customized vocabularies.
 {%- if cookiecutter.use_reduced_vocabs == "no" %}
 #names:
@@ -28,11 +28,7 @@ languages:
   pid-type: lng
   data-file: vocabularies/languages.yaml
 {%- endif %}
-# TODO: Uncoment this if you want to have all affiliations with ROR identifiers.
+# TODO: Uncomment this if you want to have all affiliations with ROR identifiers.
 # affiliations:
 #   pid-type: aff
-#   schemes:
-#     - id: ROR
-#       name: Research Organization Registry
-#       uri: "https://ror.org/"
-#       data-file: vocabularies/affiliations_ror.yaml
+#   data-file: vocabularies/affiliations_ror.yaml


### PR DESCRIPTION
Using the `affiliations_ror.yaml` broke the `invenio-cli services setup`, because the expected layout in the `vocabularies.yaml` has shifted in https://github.com/inveniosoftware/invenio-rdm-records/commit/e3df51f5a9f25c20a4234e0d6e524c8d021d8fd2
