### PR TITLE
vocabularies: switch to datastreams for affiliations

### DIFF
--- a/{{cookiecutter.project_shortname}}/app_data/vocabularies.yaml
+++ b/{{cookiecutter.project_shortname}}/app_data/vocabularies.yaml
@@ -28,7 +28,3 @@ languages:
   pid-type: lng
   data-file: vocabularies/languages.yaml
 {%- endif %}
-# TODO: Uncomment this if you want to have all affiliations with ROR identifiers.
-# affiliations:
-#   pid-type: aff
-#   data-file: vocabularies/affiliations_ror.yaml


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This removes the fixtured affiliations vocabulary now that datastreams are available as well as the outdated ror yaml file. To be merged only when https://github.com/inveniosoftware/invenio-vocabularies/pull/327 and https://github.com/inveniosoftware/invenio-app-rdm/pull/2680 are released.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
