### PR TITLE
nginx: disable chunked transfer encoding for proxied apps

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
@@ -65,6 +65,7 @@ server {
     include uwsgi_params;
     uwsgi_buffering off;
     uwsgi_request_buffering off;
+    chunked_transfer_encoding off;
     uwsgi_param Host $host;
     uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
     uwsgi_param X-Forwarded-Proto $scheme;
@@ -83,6 +84,7 @@ server {
     include uwsgi_params;
     uwsgi_buffering off;
     uwsgi_request_buffering off;
+    chunked_transfer_encoding off;
     uwsgi_param Host $host;
     uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
     uwsgi_param X-Forwarded-Proto $scheme;
@@ -105,6 +107,7 @@ server {
     include uwsgi_params;
     uwsgi_buffering off;
     uwsgi_request_buffering off;
+    chunked_transfer_encoding off;
     uwsgi_param Host $host;
     uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
     uwsgi_param X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Enabling `chunked_transfer_encoding` (HTTP/1.1) force-enables request buffering, cf: http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_request_buffering