### PR TITLE
nginx: add "application/javascript" MIME type for mjs files

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/nginx/nginx.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/nginx.conf
@@ -11,6 +11,11 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    types {
+        # The default MIME types file doesn't assign "application/javascript"
+        # to "*.mjs" files (ECMAScript modules)
+        application/javascript js mjs;
+    }
 
     # Standard log format
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '


### PR DESCRIPTION
Otherwise, `nginx` may fall back to using "application/octet-stream" which browsers may not like.
For instance, `pdfjs-dist` v4 uses `mjs` files, which is used by the new PDF previewer in `Invenio-Previewer`.
The files are transferred correctly, but because the files are reported to have the wrong MIME type they can get blocked by the browser.

This PR tells `nginx` that `mjs` files are, like `js` files, to be reported as `application/javascript`.