### PR TITLE
nginx: remove robots.txt static location

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
+++ b/{{cookiecutter.project_shortname}}/docker/nginx/conf.d/default.conf
@@ -125,9 +125,4 @@ server {
     alias /opt/invenio/var/instance/static;
     autoindex off;
   }
-  # Robots.txt file is served by nginx.
-  location /robots.txt {
-    alias /opt/invenio/var/instance/static/robots.txt;
-    autoindex off;
-  }
 }


### PR DESCRIPTION
* With the addition of the new Invenio-Sitemap module, the ``robots.txt`` file is no longer static, it's a template.

Check https://github.com/inveniosoftware/invenio-app-rdm/commit/6a0bd02892b7ba9feaa5a159a8dfb0f66e288ae8#diff-f842f0243e36637687a93857155ca64bd0f8b594394e19d1fb85f30b062ad558