### PR TITLE
Explicitly set mq hostname to avoid forgetting old messages

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -76,9 +76,13 @@ services:
       PMA_HOST: db
       MYSQL_ROOT_PASSWORD: {{cookiecutter.project_shortname}}
   {%- endif %}
+  # note: RabbitMQ uses the hostname to build the Mnesia data directory path (cf. https://www.rabbitmq.com/docs/configure)
+  #       using a randomly generated hostname "forgets" about old queued messages (e.g. celery tasks) with new builds,
+  #       and hard-coding the Mnesia path with random hostnames leads to connection issues on startup for old names
   mq:
     image: rabbitmq:3-management
     restart: "unless-stopped"
+    hostname: mq
     ports:
       - "15672:15672"
       - "5672:5672"


### PR DESCRIPTION
Docker generates random hostnames for each container, and RabbitMQ uses the hostname to construct its node name to construct the path in which to store its data (e.g. queued messages).

Thus, having randomly generated hostnames causes container rebuilds (`docker compose down && docker compose up`) to "forget" old messages, which is not desirable.

Setting the `Mnesia` directory to a value without the hostname causes issues on startup with new containers (it looks like old hostnames are still mentioned in the data but of course cannot be connected to).