### PR TITLE
Adds Flower as a Docker service

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -31,6 +31,13 @@ services:
     extends:
       file: docker-services.yml
       service: mq
+  flower:
+    extends:
+      file: docker-services.yml
+      service: flower
+    depends_on:
+      mq:
+        condition: service_started
   search:
     extends:
       file: docker-services.yml

--- a/{{cookiecutter.project_shortname}}/docker-compose.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.yml
@@ -27,6 +27,10 @@ services:
     extends:
       file: docker-services.yml
       service: mq
+  flower:
+    extends:
+      file: docker-services.yml
+      service: flower
   search:
     extends:
       file: docker-services.yml

--- a/{{cookiecutter.project_shortname}}/docker-compose.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.yml
@@ -31,6 +31,9 @@ services:
     extends:
       file: docker-services.yml
       service: flower
+    depends_on:
+      mq:
+        condition: service_started
   search:
     extends:
       file: docker-services.yml

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -86,6 +86,12 @@ services:
     ports:
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:15672:15672"
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5672:5672"
+  flower:
+    image: mher/flower:2.0.1
+    restart: "unless-stopped"
+    ports:
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5555:5555"
+    command: celery --broker=amqp://guest:guest@mq:5672/ flower
   search:
     image: opensearchproject/opensearch:2.17.1
     restart: "unless-stopped"

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -92,6 +92,9 @@ services:
     ports:
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5555:5555"
     command: celery --broker=amqp://guest:guest@mq:5672/ flower
+    depends_on:
+      mq:
+        condition: service_started
   search:
     image: opensearchproject/opensearch:2.17.1
     restart: "unless-stopped"


### PR DESCRIPTION
### Description

This adds [Flower](https://flower.readthedocs.io/) as a Docker service so folks can view the Celery job queue.

Addresses #185 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).
