### PR TITLE
fix(uwsgi): reload uWSGI workers if they take too much memory

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_rest.ini
+++ b/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_rest.ini
@@ -11,3 +11,4 @@ manage-script-name = true
 wsgi-disable-file-wrapper = true
 single-interpreter = true
 buffer-size = 8192
+reload-on-rss = 666

--- a/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_ui.ini
+++ b/{{cookiecutter.project_shortname}}/docker/uwsgi/uwsgi_ui.ini
@@ -9,3 +9,4 @@ threads = 2
 single-interpreter = true
 buffer-size = 8192
 wsgi-disable-file-wrapper = true
+reload-on-rss = 666


### PR DESCRIPTION
It looks like there's a memory leak somewhere in uWSGI or Invenio; after a while,, virtual machines will likely run out of memory and the services need to be restarted.

This PR introduces an (arbitrary) limit for the resident memory that a uWSGI worker can require before they get restarted.
That's done to prevent memory leaks from getting out of hand.