### PR TITLE
fix(mq): explicitly set file limits for the MQ container

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -83,6 +83,10 @@ services:
     image: rabbitmq:3-management
     restart: "unless-stopped"
     hostname: mq
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     ports:
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:15672:15672"
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5672:5672"


### PR DESCRIPTION
This PR addresses the issues I've brought up during the partners meeting in Graz in February.
Instead of having people edit their global Docker daemon config, we can simply just set the limits in our docker-compose files.

* having low file limits can cause some issues like rejecting new messages, which may jam parts of the system
* the RabbitMQ docs recommend a value of at least 64000: https://www.rabbitmq.com/docs/configure#with-docker