### PR TITLE
Modify OpenSearch settings in docker-services.yml

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -103,10 +103,12 @@ services:
     image: opensearchproject/opensearch:2.17.1
     restart: "unless-stopped"
     environment:
-      # settings only for development. DO NOT use in production!
+      # Settings only for development. DO NOT use in production!
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=guekxe3mvqieke1!%&ieIADE"
+      # Change the initial admin password according to the OpenSearch documentation:
+      # https://docs.opensearch.org/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=CHANGE_me_0!"
       - "DISABLE_INSTALL_DEMO_CONFIG=true"
       - "DISABLE_SECURITY_PLUGIN=true"
       - "discovery.type=single-node"


### PR DESCRIPTION
Changed initial admin password default value, to make more clear that its value should be changed.

Request by the CERN Security team.