### PR TITLE
fix: update site URL defaults for local development

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -23,6 +23,8 @@ services:
       {%- endif %}
       - "INVENIO_PROXYFIX_CONFIG={'x_for': 1, 'x_proto': 1}"
       - "INVENIO_RATELIMIT_STORAGE_URL=redis://cache:6379/3"
+      - "INVENIO_SITE_UI_URL=https://127.0.0.1"
+      - "INVENIO_SITE_API_URL=https://127.0.0.1/api"
   frontend:
     build: ./docker/nginx/
     image: {{cookiecutter.project_shortname}}-frontend

--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -168,9 +168,9 @@ APP_DEFAULT_SECURE_HEADERS['content_security_policy']['default-src'].append(
 # See https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/config.py
 
 # TODO: Set with your own hostname when deploying to production
-SITE_UI_URL = "https://127.0.0.1"
+SITE_UI_URL = "https://127.0.0.1:5000"
 
-SITE_API_URL = "https://127.0.0.1/api"
+SITE_API_URL = "https://127.0.0.1:5000/api"
 
 # Invenio-RDM-Records
 # ===================


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Change SITE_UI_URL to include port 5000 for local testing.
* Update SITE_API_URL to reflect the new port configuration.

following this change: https://github.com/inveniosoftware/invenio-cli/commit/cace5928e45adbd023ba88b35940b787f8132729
Pages, e.g. admin pages, will show errors in the console with old defaults without the port included with 

```
Connecting to 'https://127.0.0.1/api/users/all?q=&page=1&size=20&is_active=1' violates the following Content Security Policy directive: "default-src 'self' data: 'unsafe-inline' blob: cdnjs.cloudflare.com http://localhost:9000/".
Note that 'connect-src' was not explicitly set, so 'default-src' is used as a fallback.
AxiosError: Network Error
```

This PR should fix it.
We should also include that in the v14 upgrade guidance.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
