### PR TITLE
Introduce env example file

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -1,10 +1,13 @@
+{%- set postgres_user = "${POSTGRES_USER:-" ~ cookiecutter.project_shortname ~ "}" -%}
+{%- set postgres_password = "${POSTGRES_PASSWORD:-" ~ cookiecutter.project_shortname ~ "}" -%}
+{%- set postgres_db = "${POSTGRES_DB:-" ~ cookiecutter.project_shortname ~ "}" -%}
 services:
   app:
     build:
       context: ./
       args:
         - ENVIRONMENT=DEV
-        - WEBPACKEXT_NPM_PKG_CLS=${WEBPACKEXT_NPM_PKG_CLS:-pynpm:PNPMPackage}
+        - INVENIO_WEBPACKEXT_NPM_PKG_CLS=${INVENIO_WEBPACKEXT_NPM_PKG_CLS:-pynpm:PNPMPackage}
     image: {{cookiecutter.project_shortname}}
     restart: "unless-stopped"
     environment:
@@ -18,12 +21,16 @@ services:
       - "INVENIO_CELERY_RESULT_BACKEND=redis://cache:6379/2"
       - "INVENIO_COMMUNITIES_IDENTITIES_CACHE_REDIS_URL=redis://cache:6379/4"
       - "INVENIO_SEARCH_HOSTS=['search:9200']"
-      - "INVENIO_SECRET_KEY=CHANGE_ME"
-      - "INVENIO_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://{{cookiecutter.project_shortname}}:{{cookiecutter.project_shortname}}@db/{{cookiecutter.project_shortname}}"
+      - "INVENIO_SECRET_KEY=${INVENIO_SECRET_KEY:-CHANGE_ME}"
+      - "INVENIO_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://{{ postgres_user }}:{{ postgres_password }}@db/{{ postgres_db }}"
       - "INVENIO_PROXYFIX_CONFIG={'x_for': 1, 'x_proto': 1}"
       - "INVENIO_RATELIMIT_STORAGE_URL=redis://cache:6379/3"
       - "INVENIO_SITE_UI_URL=https://127.0.0.1"
       - "INVENIO_SITE_API_URL=https://127.0.0.1/api"
+{%- if cookiecutter.file_storage == 'S3'%}
+      - "INVENIO_S3_ACCESS_KEY_ID=${MINIO_ROOT_USER:-CHANGE_ME}"
+      - "INVENIO_S3_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD:-CHANGE_ME}"
+{%- endif %}
   frontend:
     build: ./docker/nginx/
     image: {{cookiecutter.project_shortname}}-frontend
@@ -41,9 +48,9 @@ services:
     image: postgres:17.10
     restart: "unless-stopped"
     environment:
-      - "POSTGRES_USER={{cookiecutter.project_shortname}}"
-      - "POSTGRES_PASSWORD={{cookiecutter.project_shortname}}"
-      - "POSTGRES_DB={{cookiecutter.project_shortname}}"
+      - "POSTGRES_USER={{ postgres_user }}"
+      - "POSTGRES_PASSWORD={{ postgres_password }}"
+      - "POSTGRES_DB={{ postgres_db }}"
     ports:
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5432:5432"
     volumes:
@@ -54,8 +61,8 @@ services:
     ports:
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5050:80"
     environment:
-      PGADMIN_DEFAULT_EMAIL: "{{cookiecutter.author_email}}"
-      PGADMIN_DEFAULT_PASSWORD: "{{cookiecutter.project_shortname}}"
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-{{cookiecutter.author_email}}}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-{{cookiecutter.project_shortname}}}
     volumes:
       - ./docker/pgadmin/servers.json:/pgadmin4/servers.json
   # note: RabbitMQ uses the hostname to build the Mnesia data directory path (cf. https://www.rabbitmq.com/docs/configure)
@@ -92,7 +99,7 @@ services:
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
       # Change the initial admin password according to the OpenSearch documentation:
       # https://docs.opensearch.org/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password
-      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=CHANGE_me_0!"
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD:-CHANGE_me_0!}"
       - "DISABLE_INSTALL_DEMO_CONFIG=true"
       - "DISABLE_SECURITY_PLUGIN=true"
       - "discovery.type=single-node"
@@ -133,8 +140,8 @@ services:
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9000:9000"
       - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9001:9001"
     environment:
-      MINIO_ROOT_USER: CHANGE_ME
-      MINIO_ROOT_PASSWORD: CHANGE_ME
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-CHANGE_ME}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-CHANGE_ME}
     volumes:
       - s3_data:/data
     command: server /data --console-address :9001

--- a/{{cookiecutter.project_shortname}}/example.env
+++ b/{{cookiecutter.project_shortname}}/example.env
@@ -1,0 +1,31 @@
+# Example local Docker Compose environment.
+#
+# Copy this file to .env and adjust values as needed. Docker Compose reads
+# .env automatically for variable interpolation.
+
+# Bind exposed service ports to localhost by default.
+DOCKER_SERVICES_IP_BIND=127.0.0.1
+
+# Build-time package class used by Invenio Webpack.
+INVENIO_WEBPACKEXT_NPM_PKG_CLS=pynpm:PNPMPackage
+
+# Secret key for local development. Change this before production use.
+INVENIO_SECRET_KEY=CHANGE_ME
+
+# PostgreSQL credentials for the local development service.
+POSTGRES_USER={{cookiecutter.project_shortname}}
+POSTGRES_PASSWORD={{cookiecutter.project_shortname}}
+POSTGRES_DB={{cookiecutter.project_shortname}}
+
+# pgAdmin login for the local development service.
+PGADMIN_DEFAULT_EMAIL={{cookiecutter.author_email}}
+PGADMIN_DEFAULT_PASSWORD={{cookiecutter.project_shortname}}
+
+# Initial OpenSearch admin password for the development container.
+OPENSEARCH_INITIAL_ADMIN_PASSWORD=CHANGE_me_0!
+
+{%- if cookiecutter.file_storage == 'S3'%}
+# MinIO credentials for the local S3-compatible development service.
+MINIO_ROOT_USER=CHANGE_ME
+MINIO_ROOT_PASSWORD=CHANGE_ME
+{%- endif %}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

build based on https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/304

## Background

During review of the [cookiecutter upgrade PR](https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/304#discussion_r3348503087), we discussed reducing hard-coded `CHANGE_ME` values in `docker-services` and moving configuration into environment files.

The discussion surfaced a few possible approaches:

* Use a single `.env` file for both service/container configuration and Invenio application configuration.
* Keep service and application configuration separated (e.g. `.containers-env` and `.invenio-env`).
* Use an additional private configuration file such as `invenio-private.cfg` for application secrets, mounted at runtime rather than baked into images.
* Provide example configuration files (`example.env` or `.env.example`) and keep real environment files excluded from version control.

## Goal

Evaluate whether the remaining hard-coded `CHANGE_ME` values should be moved to environment variables and whether we should consolidate configuration into a single `.env`-based workflow (or adopt another approach).



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
