### PR TITLE
Explicitly set default logging level

### DIFF
--- a/{{cookiecutter.project_shortname}}/invenio.cfg
+++ b/{{cookiecutter.project_shortname}}/invenio.cfg
@@ -228,6 +228,7 @@ ADMINISTRATION_DISPLAY_VERSIONS = [
     ("invenio-app-rdm", f"v{__version__}"),
     ("{{ cookiecutter.project_shortname }}", "v1.0.0"),
 ]
+
 # Asset bundling configuration
 # ---------------------------
 
@@ -242,4 +243,14 @@ STATS_EVENTS_UTC_DATETIME_ENABLED = True
 When set to ``False``, naive UTC datetimes are used (tzinfo is
 stripped via ``datetime.replace(tzinfo=None)``). Set to ``True`` to use
 timezone-aware UTC datetimes with explicit UTC timezone information.
+"""
+
+# Invenio-Logging
+# ---------------
+
+LOGGING_CONSOLE_LEVEL = "DEBUG"
+"""Logger level for the default console logger.
+
+Set to a valid Python logging level: ``CRITICAL``, ``ERROR``, ``WARNING``,
+``INFO``, ``DEBUG``, or ``NOTSET``.
 """


### PR DESCRIPTION
Distantly related ot https://github.com/inveniosoftware/invenio-logging/pull/86

I'm setting the default logging level to `DEBUG` because that's virtually the same as the existing behavior, and probably the most appropriate for development setups.
Having the config variable mentioned explicitly should raise awareness about this setting for production use.
