### PR TITLE
fix(ports): open up the web ports to everybody

### DIFF
--- a/{{cookiecutter.project_shortname}}/docker-compose.full.yml
+++ b/{{cookiecutter.project_shortname}}/docker-compose.full.yml
@@ -69,8 +69,8 @@ services:
       - web-ui
       - web-api
     ports:
-      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:80:80"
-      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:443:443"
+      - "${DOCKER_WEB_IP_BIND:-0.0.0.0}:80:80"
+      - "${DOCKER_WEB_IP_BIND:-0.0.0.0}:443:443"
   # UI Application
   web-ui:
     extends:

--- a/{{cookiecutter.project_shortname}}/docker-services.yml
+++ b/{{cookiecutter.project_shortname}}/docker-services.yml
@@ -29,8 +29,8 @@ services:
     image: {{cookiecutter.project_shortname}}-frontend
     restart: "unless-stopped"
     ports:
-      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:80:80"
-      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:443:443"
+      - "${DOCKER_WEB_IP_BIND:-0.0.0.0}:80:80"
+      - "${DOCKER_WEB_IP_BIND:-0.0.0.0}:443:443"
   cache:
     image: redis:7
     restart: "unless-stopped"


### PR DESCRIPTION
In contrast to other services, the web ports for nginx (80 and 443) are actually supposed to be reached by the outside world.
So for those, we drop the `DOCKER_SERVICES_IP_BIND` restriction.